### PR TITLE
Fix %tooltip text field replacements

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -5363,7 +5363,7 @@ function WeakAuras.GetAuraTooltipInfo(unit, index, filter)
   local tooltip = WeakAuras.GetHiddenTooltip();
   tooltip:ClearLines();
   tooltip:SetUnitAura(unit, index, filter);
-  local tooltipTextLine = select(5, tooltip:GetRegions())
+  local tooltipTextLine = select(12, tooltip:GetRegions())
 
   local tooltipText = tooltipTextLine and tooltipTextLine:GetObjectType() == "FontString" and tooltipTextLine:GetText() or "";
   local debuffType = "none";


### PR DESCRIPTION
Fixed the %tooltip, %tooltip1, %tooltip2 and %tooltip3 text fields when using the "Use Tooltip Information" trigger option